### PR TITLE
CEDS-2906 Implement stub endpoint for Declarations Information service

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ If LRN starts with:
 - 'D' - Stub will send Accepted and Additional Documents Required notifications
 - other letters will invoke default behaviour which is Accepted notification
 
+### Customs Declarations Information stubbing
+
+    GET         /mrn/:mrn/status
+
+This endpoint returns mocked DeclarationStatusResponse with dynamic EORI and MRN taken from the request.
+MRN is part of the url, but EORI is taken from Auth service using `Authorization` token.
+
+By default the response is successful.
+
+In case you need unsuccessful response to be returned, these can be triggered by providing MRN as per rules below:
+- ends with '9999' - Not Found (404) response
+
 ### License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").

--- a/app/uk/gov/hmrc/customs/declarations/stub/controllers/DeclarationsInformationStubController.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/controllers/DeclarationsInformationStubController.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.controllers
+
+import javax.inject.{Inject, Singleton}
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.customs.declarations.stub.controllers.actions.AuthAction
+import uk.gov.hmrc.customs.declarations.stub.models.declarationstatus.DeclarationStatusResponse._
+import uk.gov.hmrc.customs.declarations.stub.services.DeclarationStatusResponseBuilder
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+@Singleton
+class DeclarationsInformationStubController @Inject()(
+  cc: ControllerComponents,
+  authenticate: AuthAction,
+  declarationStatusResponseBuilder: DeclarationStatusResponseBuilder
+) extends BackendController(cc) {
+
+  def getDeclarationStatus(mrn: String): Action[AnyContent] = authenticate { request =>
+    val response = declarationStatusResponseBuilder.buildDeclarationStatus(request.eori, mrn)
+
+    response match {
+      case SuccessfulResponse(_) => Ok(response.body)
+      case NotFoundResponse      => NotFound(response.body)
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/customs/declarations/stub/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/controllers/actions/AuthAction.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.controllers.actions
+
+import com.google.inject.{ImplementedBy, Inject}
+import play.api.mvc._
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
+import uk.gov.hmrc.customs.declarations.stub.models.requests.{AuthenticatedRequest, SignedInUser}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.HeaderCarrierConverter
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AuthActionImpl @Inject()(override val authConnector: AuthConnector, cc: ControllerComponents)(
+  implicit override val executionContext: ExecutionContext
+) extends AuthAction with AuthorisedFunctions {
+
+  override val parser: BodyParser[AnyContent] = cc.parsers.defaultBodyParser
+
+  private val hmrcCusOrgEnrolmentKey = "HMRC-CUS-ORG"
+  private val eoriNumberIdentifierKey = "EORINumber"
+
+  override def invokeBlock[A](request: Request[A], block: AuthenticatedRequest[A] => Future[Result]): Future[Result] = {
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSessionAndRequest(request.headers)
+
+    authorised(Enrolment(hmrcCusOrgEnrolmentKey))
+      .retrieve(allEnrolments) { allEnrolments: Enrolments =>
+        val eori = getEoriEnrolment(allEnrolments)
+
+        if (eori.isEmpty) {
+          Future.successful(Results.Unauthorized)
+        } else {
+          val cdsLoggedInUser = SignedInUser(eori.get.value, allEnrolments)
+          block(AuthenticatedRequest(request, cdsLoggedInUser))
+        }
+      }
+  }
+
+  private def getEoriEnrolment(enrolments: Enrolments): Option[EnrolmentIdentifier] =
+    enrolments.getEnrolment(hmrcCusOrgEnrolmentKey).flatMap(_.getIdentifier(eoriNumberIdentifierKey))
+}
+
+@ImplementedBy(classOf[AuthActionImpl])
+trait AuthAction extends ActionBuilder[AuthenticatedRequest, AnyContent]

--- a/app/uk/gov/hmrc/customs/declarations/stub/models/declarationstatus/DeclarationStatusResponse.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/models/declarationstatus/DeclarationStatusResponse.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.models.declarationstatus
+
+import scala.xml.{Elem, XML}
+
+trait DeclarationStatusResponse {
+  val body: Elem
+}
+
+object DeclarationStatusResponse {
+  case object NotFoundResponse extends DeclarationStatusResponse {
+    override val body: Elem = NotFoundResponseBody
+  }
+  case class SuccessfulResponse(override val body: Elem) extends DeclarationStatusResponse
+
+  val NotFoundResponseBody: Elem = XML.loadString(
+    "<?xml version='1.0' encoding='UTF-8'?>\n" +
+      <errorResponse>
+      <code>CDS60001</code>
+      <message>Declaration not found</message>
+    </errorResponse>
+  )
+
+  //noinspection ScalaStyle
+  def successfulResponseBody(eori: String, mrn: String): Elem =
+    <p:DeclarationStatusResponse xsi:schemaLocation="http://gov.uk/customs/declarationInformationRetrieval/status/v2"
+                                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                 xmlns:p4="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:6"
+                                 xmlns:p3="urn:wco:datamodel:WCO:Declaration_DS:DMS:2"
+                                 xmlns:p2="urn:wco:datamodel:WCO:DEC-DMS:2"
+                                 xmlns:p1="urn:wco:datamodel:WCO:Response_DS:DMS:2"
+                                 xmlns:p="http://gov.uk/customs/declarationInformationRetrieval/status/v2">
+      <p:DeclarationStatusDetails>
+        <p:Declaration>
+          <p:AcceptanceDateTime>
+            <p1:DateTimeString formatCode="304">20201206110757Z</p1:DateTimeString>
+          </p:AcceptanceDateTime>
+          <p:ID>{mrn}</p:ID>
+          <p:VersionID>1</p:VersionID>
+          <p:ReceivedDateTime>
+            <p:DateTimeString formatCode="304">20201206110757Z</p:DateTimeString>
+          </p:ReceivedDateTime>
+          <p:GoodsReleasedDateTime>
+            <p:DateTimeString formatCode="304">20201206110757Z</p:DateTimeString>
+          </p:GoodsReleasedDateTime>
+          <p:ROE>6</p:ROE>
+          <p:ICS>15</p:ICS>
+          <p:IRC>000</p:IRC>
+        </p:Declaration>
+        <p2:Declaration>
+          <p2:FunctionCode>9</p2:FunctionCode>
+          <p2:TypeCode>IMZ</p2:TypeCode>
+          <p2:GoodsItemQuantity unitCode="NPR">100</p2:GoodsItemQuantity>
+          <p2:TotalPackageQuantity>10</p2:TotalPackageQuantity>
+          <p2:Submitter>
+            <p2:ID>{eori}</p2:ID>
+          </p2:Submitter>
+          <p2:GoodsShipment>
+            <p2:PreviousDocument>
+              <p2:ID>18GBAKZ81EQJ2FGVR</p2:ID>
+              <p2:TypeCode>DCR</p2:TypeCode>
+            </p2:PreviousDocument>
+            <p2:PreviousDocument>
+              <p2:ID>18GBAKZ81EQJ2FGVA</p2:ID>
+              <p2:TypeCode>MCR</p2:TypeCode>
+            </p2:PreviousDocument>
+            <p2:PreviousDocument>
+              <p2:ID>18GBAKZ81EQJ2FGVB</p2:ID>
+              <p2:TypeCode>MCR</p2:TypeCode>
+            </p2:PreviousDocument>
+            <p2:PreviousDocument>
+              <p2:ID>18GBAKZ81EQJ2FGVC</p2:ID>
+              <p2:TypeCode>DCR</p2:TypeCode>
+            </p2:PreviousDocument>
+            <p2:PreviousDocument>
+              <p2:ID>18GBAKZ81EQJ2FGVD</p2:ID>
+              <p2:TypeCode>MCR</p2:TypeCode>
+            </p2:PreviousDocument>
+            <p2:UCR>
+              <p2:TraderAssignedReferenceID>20GBAKZ81EQJ2WXYZ</p2:TraderAssignedReferenceID>
+            </p2:UCR>
+          </p2:GoodsShipment>
+        </p2:Declaration>
+      </p:DeclarationStatusDetails>
+    </p:DeclarationStatusResponse>
+
+}

--- a/app/uk/gov/hmrc/customs/declarations/stub/models/requests/AuthenticatedRequest.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/models/requests/AuthenticatedRequest.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.models.requests
+
+import play.api.mvc.{Request, WrappedRequest}
+
+case class AuthenticatedRequest[A](request: Request[A], user: SignedInUser) extends WrappedRequest[A](request) {
+  lazy val eori: String = user.eori
+}

--- a/app/uk/gov/hmrc/customs/declarations/stub/models/requests/SignedInUser.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/models/requests/SignedInUser.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.models.requests
+
+import uk.gov.hmrc.auth.core.Enrolments
+
+case class SignedInUser(eori: String, enrolments: Enrolments)

--- a/app/uk/gov/hmrc/customs/declarations/stub/services/DeclarationStatusResponseBuilder.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/services/DeclarationStatusResponseBuilder.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.services
+
+import uk.gov.hmrc.customs.declarations.stub.models.declarationstatus.DeclarationStatusResponse
+import uk.gov.hmrc.customs.declarations.stub.models.declarationstatus.DeclarationStatusResponse._
+
+class DeclarationStatusResponseBuilder {
+
+  def buildDeclarationStatus(eori: String, mrn: String): DeclarationStatusResponse = mrn match {
+    case mrn if mrn.endsWith("9999") => NotFoundResponse
+    case _                           => SuccessfulResponse(successfulResponseBody(eori, mrn))
+  }
+}

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -7,6 +7,8 @@ POST          /cancellation-requests                                            
 
 GET           /last-submission                                                               uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationStubController.lastSubmit()
 
+GET           /mrn/:mrn/status                                                               uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationsInformationStubController.getDeclarationStatus(mrn)
+
 POST          /customs-declare-imports/                                                      uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationStubController.submitNoNotification()
 
 POST          /customs-declare-imports/cancellation-requests                                 uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationStubController.cancelNoNotification()

--- a/test/uk/gov/hmrc/customs/declarations/stub/base/AuthConnectorMock.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/base/AuthConnectorMock.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.base
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.Retrieval
+import uk.gov.hmrc.customs.declarations.stub.controllers.actions.AuthActionImpl
+import uk.gov.hmrc.customs.declarations.stub.models.requests.SignedInUser
+import uk.gov.hmrc.customs.declarations.stub.testdata.CommonTestData._
+
+import scala.concurrent.ExecutionContext.global
+import scala.concurrent.Future
+
+trait AuthConnectorMock extends MockitoSugar with BeforeAndAfterEach { self: Suite =>
+
+  val authConnectorMock: AuthConnector = mock[AuthConnector]
+
+  val authActionMock = new AuthActionImpl(authConnectorMock, stubControllerComponents())(global)
+
+  def authorizedUser(user: SignedInUser = signedInUser(eori)): Unit =
+    when(authConnectorMock.authorise(any(), any[Retrieval[Enrolments]])(any(), any()))
+      .thenReturn(Future.successful(user.enrolments))
+
+  def userWithoutEori(): Unit =
+    when(authConnectorMock.authorise(any(), any[Retrieval[Enrolments]])(any(), any()))
+      .thenReturn(Future.successful(Enrolments(Set())))
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(authConnectorMock)
+  }
+
+  override def afterEach(): Unit = {
+    reset(authConnectorMock)
+    super.afterEach()
+  }
+}

--- a/test/uk/gov/hmrc/customs/declarations/stub/controllers/DeclarationsInformationStubControllerSpec.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/controllers/DeclarationsInformationStubControllerSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.controllers
+
+import org.mockito.ArgumentMatchers.{anyString, eq => eqTo}
+import org.mockito.Mockito._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpec}
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.customs.declarations.stub.base.AuthConnectorMock
+import uk.gov.hmrc.customs.declarations.stub.models.declarationstatus.DeclarationStatusResponse._
+import uk.gov.hmrc.customs.declarations.stub.services.DeclarationStatusResponseBuilder
+import uk.gov.hmrc.customs.declarations.stub.testdata.CommonTestData.{eori, mrn, signedInUser}
+
+import scala.xml.XML
+
+class DeclarationsInformationStubControllerSpec
+    extends WordSpec with MustMatchers with MockitoSugar with ScalaFutures with BeforeAndAfterEach
+    with AuthConnectorMock {
+
+  private val declarationsInformationStubService = mock[DeclarationStatusResponseBuilder]
+
+  private val controller = new DeclarationsInformationStubController(
+    stubControllerComponents(),
+    authActionMock,
+    declarationsInformationStubService
+  )
+
+  private val request = FakeRequest()
+  private val successfulResponse = SuccessfulResponse(<testResponse/>)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    reset(declarationsInformationStubService)
+    authorizedUser(signedInUser(eori))
+    when(declarationsInformationStubService.buildDeclarationStatus(anyString(), anyString()))
+      .thenReturn(successfulResponse)
+  }
+
+  override def afterEach(): Unit = {
+    reset(declarationsInformationStubService)
+    super.afterEach()
+  }
+
+  "DeclarationsInformationStubController on getDeclarationStatus" when {
+
+    "user is not authorized" should {
+
+      "return Unauthorized response" in {
+
+        userWithoutEori()
+
+        val result = controller.getDeclarationStatus(mrn)(request)
+        status(result) mustBe UNAUTHORIZED
+
+      }
+    }
+
+    "user is authorized" should {
+
+      "call DeclarationsInformationStubService" in {
+
+        controller.getDeclarationStatus(mrn)(request).futureValue
+
+        verify(declarationsInformationStubService).buildDeclarationStatus(eqTo(eori), eqTo(mrn))
+      }
+    }
+
+    "user is authorized" when {
+
+      "DeclarationsInformationStubService returns Successful response" should {
+
+        "return Ok (200) with that response" in {
+
+          val result = controller.getDeclarationStatus(mrn)(request)
+
+          status(result) mustBe OK
+          XML.loadString(contentAsString(result)) mustBe successfulResponse.body
+        }
+      }
+
+      "DeclarationsInformationStubService returns NotFound response" should {
+
+        "return NotFound (404) response" in {
+
+          when(declarationsInformationStubService.buildDeclarationStatus(anyString(), anyString()))
+            .thenReturn(NotFoundResponse)
+
+          val result = controller.getDeclarationStatus(mrn)(request)
+
+          status(result) mustBe NOT_FOUND
+          XML.loadString(contentAsString(result)) mustBe NotFoundResponse.body
+        }
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/customs/declarations/stub/controllers/DeclarationsStubControllerSpec.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/controllers/DeclarationsStubControllerSpec.scala
@@ -36,7 +36,7 @@ import uk.gov.hmrc.auth.core.retrieve.Retrieval
 import uk.gov.hmrc.customs.declarations.stub.config.AppConfig
 import uk.gov.hmrc.customs.declarations.stub.connector.NotificationConnector
 import uk.gov.hmrc.customs.declarations.stub.repositories.{Client, ClientRepository}
-import uk.gov.hmrc.customs.declarations.stub.util.TestData._
+import uk.gov.hmrc.customs.declarations.stub.testdata.xmls.SubmissionRequests._
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/test/uk/gov/hmrc/customs/declarations/stub/services/DeclarationStatusResponseBuilderSpec.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/services/DeclarationStatusResponseBuilderSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.services
+
+import org.scalatest.{MustMatchers, WordSpec}
+import uk.gov.hmrc.customs.declarations.stub.models.declarationstatus.DeclarationStatusResponse
+import uk.gov.hmrc.customs.declarations.stub.models.declarationstatus.DeclarationStatusResponse.{
+  NotFoundResponse,
+  SuccessfulResponse
+}
+import uk.gov.hmrc.customs.declarations.stub.testdata.CommonTestData
+
+class DeclarationStatusResponseBuilderSpec extends WordSpec with MustMatchers {
+
+  private val declarationStatusResponseBuilder = new DeclarationStatusResponseBuilder()
+
+  "DeclarationStatusResponseBuilder on buildDeclarationStatus" when {
+
+    val eori = CommonTestData.eori
+
+    "provided with MRN ending with '9999'" should {
+
+      "return NotFoundResponse with correct body" in {
+
+        val mrn = "18GB9JLC3CU1LF9999"
+
+        val result = declarationStatusResponseBuilder.buildDeclarationStatus(eori, mrn)
+
+        val expectedResult = NotFoundResponse
+
+        result mustBe expectedResult
+      }
+    }
+
+    "provided with MRN not ending with '9999'" should {
+
+      "return SuccessfulResponse with correct body" in {
+
+        val mrn = CommonTestData.mrn
+
+        val result = declarationStatusResponseBuilder.buildDeclarationStatus(eori, mrn)
+
+        val expectedResult = SuccessfulResponse(DeclarationStatusResponse.successfulResponseBody(eori, mrn))
+
+        result mustBe expectedResult
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/customs/declarations/stub/testdata/CommonTestData.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/testdata/CommonTestData.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.testdata
+
+import uk.gov.hmrc.auth.core.{Enrolment, Enrolments}
+import uk.gov.hmrc.customs.declarations.stub.models.requests.SignedInUser
+
+object CommonTestData {
+
+  val eori: String = "GB12345678"
+
+  val mrn: String = "18GB9JLC3CU1LFGVR2"
+
+  def signedInUser(eori: String): SignedInUser =
+    SignedInUser(eori, Enrolments(Set(Enrolment("HMRC-CUS-ORG").withIdentifier("EORINumber", eori))))
+
+}

--- a/test/uk/gov/hmrc/customs/declarations/stub/testdata/xmls/SubmissionRequests.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/testdata/xmls/SubmissionRequests.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.customs.declarations.stub.util
+package uk.gov.hmrc.customs.declarations.stub.testdata.xmls
 
 import scala.xml.Elem
 
-object TestData {
+object SubmissionRequests {
 
   val validCancellationXml: Elem =
     <md:MetaData xmlns="urn:wco:datamodel:WCO:DEC-DMS:2" xmlns:md="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2">


### PR DESCRIPTION
The new endpoint returns DeclarationStatusResponse with dynamic EORI and
MRN taken from incoming request.
For MRN ending with '9999' it returns NotFound response which mocks the
behavior of Declarations Information service for two scenarios from
Exports perspective:
1. There is no declaration with given MRN.
2. There is a declaration with given MRN, but it belongs to a different
user.