### PR TITLE
[CEDS-2907] Add Upscan endpoints to stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 
  [ ![Download](https://api.bintray.com/packages/hmrc/releases/customs-declarations-stub/images/download.svg) ](https://bintray.com/hmrc/releases/customs-declarations-stub/_latestVersion)
 
-This application provides a stub for Customs Declarations API that enables frontend services that use Customs Declarations API with a stub to develop locally without depending on the API. 
+This application provides a stubs for the following services:
+* Customs Declarations API service - that enables frontend services that use Customs Declarations API with a stub to develop locally without depending on the API. 
+* Customs Data Store service - just for the email verification endpoint (no other endpoints are stubbed here)
+* Upscan service - the 'batch-file-upload' and 's3-bucket' endpoints
 
-
+##Customs Declarations API service
 ### Usage custom notifications
 If you send a declaration with specific letter at the beginning of the LRN you can control what notifications you receive.
 
@@ -15,7 +18,7 @@ If LRN starts with:
 - 'D' - Stub will send Accepted and Additional Documents Required notifications
 - other letters will invoke default behaviour which is Accepted notification
 
-### Customs Declarations Information stubbing
+## Customs Declarations Information stubbing
 ```
     GET    /mrn/:mrn/status
 ```
@@ -27,7 +30,7 @@ By default the response is successful.
 In case you need unsuccessful response to be returned, these can be triggered by providing MRN as per rules below:
 - ends with '9999' - Not Found (404) response
 
-
+## Customs Data Store service
 ### eMail Address Verification
 ```
     GET    /eori/<EORI>/verified-email
@@ -42,7 +45,13 @@ otherwise a 404(NOT_FOUND) response is returned.
 
 Note that for any given EORI number ending in `99`, the associated email address will always be considered **unverified**, resulting accordingly in a 404(NOT_FOUND) response.
 
+## Upscan service
+Endpoint to simulate an S3 url that accepts a multipart file upload and sends the required success/failure notification to the SFUS backend service. 
 
-### License
+```
+    POST    /upscan/s3-bucket
+```
+
+## License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").

--- a/app/uk/gov/hmrc/customs/declarations/stub/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/config/AppConfig.scala
@@ -32,4 +32,10 @@ class AppConfig @Inject()(runModeConfiguration: Configuration, servicesConfig: S
     callbackUrl = servicesConfig.baseUrl("client") + loadConfig("microservice.services.client.uri"),
     token = loadConfig("microservice.services.client.token")
   )
+
+  val cdsFileUploadBaseUrl = servicesConfig.baseUrl("cds-file-upload")
+
+  val cdsFileUploadFrontendBaseUrl = servicesConfig.baseUrl("cds-file-upload-frontend")
+
+  val upscanBaseUrl = servicesConfig.baseUrl("upscan")
 }

--- a/app/uk/gov/hmrc/customs/declarations/stub/controllers/UpscanStubController.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/controllers/UpscanStubController.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.controllers
+
+import play.api.http.{ContentTypes, HeaderNames}
+import play.api.mvc.{Action, Codec, MessagesControllerComponents}
+import play.api.Logging
+import uk.gov.hmrc.customs.declarations.stub.config.AppConfig
+import uk.gov.hmrc.customs.declarations.stub.models.upscan._
+import uk.gov.hmrc.customs.declarations.stub.models.upscan.Field._
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{Inject, Singleton}
+import scala.xml._
+
+@Singleton
+class UpscanStubController @Inject()(appConfig: AppConfig, httpClient: HttpClient, mcc: MessagesControllerComponents) extends BackendController(mcc) with Logging {
+
+  implicit val ec = mcc.executionContext
+
+  def waiting(ref: String) = {
+    Waiting(
+      UploadRequest(
+        href = s"${appConfig.upscanBaseUrl}/upscan/s3-bucket",
+        fields = Map(
+          Algorithm.toString -> "AWS4-HMAC-SHA256",
+          Signature.toString -> "xxxx",
+          Key.toString -> "xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+          ACL.toString -> "private",
+          Credentials.toString -> "ASIAxxxxxxxxx/20180202/eu-west-2/s3/aws4_request",
+          Policy.toString -> "xxxxxxxx==",
+          SuccessRedirect.toString -> s"${appConfig.cdsFileUploadFrontendBaseUrl}/cds-file-upload-service/upload/upscan-success/${ref}",
+          ErrorRedirect.toString -> s"${appConfig.cdsFileUploadFrontendBaseUrl}/cds-file-upload-service/upload/upscan-error/${ref}"
+        )
+      )
+    )
+  }
+
+  // for now, we will just return some random
+  def handleBatchFileUploadRequest: Action[NodeSeq] = Action(parse.xml) { implicit req =>
+    val xmlBodyString = req.body.mkString
+    logger.info(s"Batch file upload request: $xmlBodyString")
+    Thread.sleep(100)
+
+    val fileGroupSize = (scala.xml.XML.loadString(xmlBodyString) \ "FileGroupSize").text.toInt
+
+    val resp = FileUploadResponse((1 to fileGroupSize).map { i =>
+      FileUpload(i.toString, waiting(i.toString), id = s"$i")
+    }.toList)
+
+    Ok(XmlHelper.toXml(resp)).as(ContentTypes.XML)
+  }
+
+  def handleS3FileUploadRequest = Action(parse.multipartFormData) { implicit req =>
+    val redirectLocation = req.body.dataParts("success_action_redirect").head
+    val reference = redirectLocation.split("/").last
+    callBack(reference)
+    SeeOther(redirectLocation).withHeaders("Location" -> redirectLocation)
+  }
+
+  def callBack(ref: String)(implicit hc: HeaderCarrier) = {
+    Thread.sleep(1000)
+
+    val notification =
+      <Root>
+        <FileReference>{ref}</FileReference>
+        <BatchId>5e634e09-77f6-4ff1-b92a-8a9676c715c4</BatchId>
+        <FileName>File_{ref}.pdf</FileName>
+        <Outcome>SUCCESS</Outcome>
+        <Details>[detail block]</Details>
+      </Root>
+
+    val url = appConfig.cdsFileUploadBaseUrl + "/internal/notification"
+
+    val header: (String, String) = HeaderNames.CONTENT_TYPE -> ContentTypes.XML(Codec.utf_8)
+
+    httpClient.POSTString[HttpResponse](url, notification.toString(), Seq(header))
+  }
+}
+
+object XmlHelper {
+
+  def toXml(field: (String, String)): Elem =
+    <a/>.copy(label = field._1, child = Seq(Text(field._2)))
+
+  def toXml(uploadRequest: UploadRequest): Elem =
+    <UploadRequest>
+      <Href>
+        {uploadRequest.href}
+      </Href>
+      <Fields>
+        {uploadRequest.fields.map(toXml)}
+      </Fields>
+    </UploadRequest>
+
+  def toXml(upload: FileUpload): Elem = {
+    val request = upload.state match {
+      case Waiting(req) => toXml(req)
+      case _            => NodeSeq.Empty
+    }
+    <File>
+      <Reference>
+        {upload.reference}
+      </Reference>{request}
+    </File>
+  }
+
+  def toXml(response: FileUploadResponse): Elem =
+    <FileUploadResponse xmlns="hmrc:fileupload">
+      <Files>
+        {response.uploads.map(toXml)}
+      </Files>
+    </FileUploadResponse>
+}

--- a/app/uk/gov/hmrc/customs/declarations/stub/models/upscan/FileState.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/models/upscan/FileState.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.models.upscan
+
+import play.api.libs.json.{Format, JsError, JsObject, JsResult, JsString, JsSuccess, JsValue, Json}
+
+sealed trait FileState
+final case class Waiting(uploadRequest: UploadRequest) extends FileState
+case object Uploaded extends FileState
+case object Successful extends FileState
+case object Failed extends FileState
+case object VirusDetected extends FileState
+case object UnacceptableMimeType extends FileState
+
+object Waiting {
+
+  implicit val format = Json.format[Waiting]
+}
+
+object FileState {
+
+  private val waiting = "waiting"
+  private val uploaded = "uploaded"
+  private val success = "success"
+  private val failed = "failed"
+  private val virus = "virus"
+  private val mimeType = "mimeType`"
+
+  implicit val format = new Format[FileState] {
+    override def writes(o: FileState): JsValue = o match {
+      case Waiting(request)     => Json.obj(waiting -> Json.toJson(request))
+      case Uploaded             => JsString(uploaded)
+      case Successful           => JsString(success)
+      case Failed               => JsString(failed)
+      case VirusDetected        => JsString(virus)
+      case UnacceptableMimeType => JsString(mimeType)
+    }
+
+    override def reads(json: JsValue): JsResult[FileState] = json match {
+      case JsString(`uploaded`) => JsSuccess(Uploaded)
+      case JsString(`success`)  => JsSuccess(Successful)
+      case JsString(`failed`)   => JsSuccess(Failed)
+      case JsString(`virus`)    => JsSuccess(VirusDetected)
+      case JsString(`mimeType`) => JsSuccess(UnacceptableMimeType)
+      case JsObject(map) =>
+        map.get(waiting) match {
+          case Some(request) => Json.fromJson[UploadRequest](request).map(Waiting(_))
+          case None          => JsError("Unable to parse FileState")
+        }
+      case _ => JsError("Unable to parse FileState")
+    }
+  }
+}

--- a/app/uk/gov/hmrc/customs/declarations/stub/models/upscan/FileUploadRequest.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/models/upscan/FileUploadRequest.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.models.upscan
+
+import java.util.UUID
+import scala.xml.Elem
+
+case class FileUploadFile(fileSequenceNo: Int, documentType: String, serviceUrl: String) {
+  private val uuid = UUID.randomUUID()
+  val successRedirect = serviceUrl + "/cds-file-upload-service/upload/upscan-success/" + uuid
+  val errorRedirect = serviceUrl + "/cds-file-upload-service/upload/upscan-error/" + uuid
+
+  def toXml: Elem =
+    <File>
+      <FileSequenceNo>{fileSequenceNo}</FileSequenceNo>
+      <DocumentType>{documentType}</DocumentType>
+      <SuccessRedirect>{successRedirect}</SuccessRedirect>
+      <ErrorRedirect>{errorRedirect}</ErrorRedirect>
+    </File>
+}

--- a/app/uk/gov/hmrc/customs/declarations/stub/models/upscan/FileUploadResponse.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/models/upscan/FileUploadResponse.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.declarations.stub.models.upscan
+
+import play.api.Logging
+import play.api.libs.json._
+
+import scala.xml.Elem
+
+case class UploadRequest(href: String, fields: Map[String, String])
+
+object UploadRequest {
+  implicit val format = Json.format[UploadRequest]
+}
+
+case class FileUpload(reference: String, state: FileState, filename: String = "", id: String)
+
+object FileUpload {
+  implicit val format = Json.format[FileUpload]
+}
+
+abstract case class FileUploadResponse(uploads: List[FileUpload])
+
+object FileUploadResponse extends Logging {
+  implicit val format = Json.format[FileUploadResponse]
+
+  def apply(files: List[FileUpload]): FileUploadResponse = new FileUploadResponse(files.sortBy(_.reference)) {}
+
+  def fromXml(xml: Elem): FileUploadResponse = {
+    logger.info("File Upload Response " + xml)
+    val files: List[FileUpload] = (xml \ "Files" \ "_").theSeq.collect {
+      case file =>
+        val reference = (file \ "Reference").text.trim
+        val href = (file \ "UploadRequest" \ "Href").text.trim
+        val successUrl = (file \ "UploadRequest" \ "Fields" \ "success_action_redirect").text.trim
+        val fields: Map[String, String] =
+          (file \ "UploadRequest" \ "Fields" \ "_").theSeq.collect {
+            case field if field.label == "success-action-redirect" => "success_action_redirect" -> field.text.trim
+            case field if field.label == "error-action-redirect"   => "error_action_redirect" -> field.text.trim
+            case field                                             => field.label -> field.text.trim
+          }.toMap
+
+        FileUpload(reference, Waiting(UploadRequest(href, fields)), id = successUrl.split('/').last)
+    }.toList
+
+    FileUploadResponse(files)
+  }
+}
+
+abstract class Field(value: String) {
+  override def toString: String = value
+}
+
+object Field {
+  final case object ContentType extends Field("Content-Type")
+  final case object ACL extends Field("acl")
+  final case object Key extends Field("key")
+  final case object Policy extends Field("policy")
+  final case object Algorithm extends Field("x-amz-algorithm")
+  final case object Credentials extends Field("x-amz-credential")
+  final case object Date extends Field("x-amz-date")
+  final case object Callback extends Field("x-amz-meta-callback-url")
+  final case object Signature extends Field("x-amz-signature")
+  final case object SuccessRedirect extends Field("success_action_redirect")
+  final case object ErrorRedirect extends Field("error_action_redirect")
+
+  val values: Set[Field] = Set(ContentType, ACL, Key, Policy, Algorithm, Credentials, Date, Signature, Callback)
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -77,6 +77,24 @@ microservice {
       uri = "/customs-declare-exports/notify"
       token = "abc59609za2q"
     }
+
+    cds-file-upload {
+      protocol = http
+      host = localhost
+      port = 6795
+    }
+
+    cds-file-upload-frontend {
+      protocol = http
+      host = localhost #must be a public domain in MDTP environments e.g. 'www.staging.tax.service.gov.uk'
+      port = 6793
+    }
+
+    upscan {
+      protocol = http
+      host = localhost
+      port = 6790
+    }
   }
 }
 

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,6 +1,8 @@
 # Add all the application routes to the app.routes file
 ->            /                                                                              health.Routes
 
+# Customs Declarations endpoints
+
 POST          /                                                                              uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationStubController.submit()
 
 POST          /cancellation-requests                                                         uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationStubController.cancel()
@@ -12,6 +14,18 @@ GET           /mrn/:mrn/status                                                  
 POST          /customs-declare-imports/                                                      uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationStubController.submitNoNotification()
 
 POST          /customs-declare-imports/cancellation-requests                                 uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationStubController.cancelNoNotification()
+
+POST          /file-upload                                                                   uk.gov.hmrc.customs.declarations.stub.controllers.UpscanStubController.handleBatchFileUploadRequest
+
+# Upscan endpoint
+
+POST          /upscan/s3-bucket                                                              uk.gov.hmrc.customs.declarations.stub.controllers.UpscanStubController.handleS3FileUploadRequest
+
+# Customs Data Store endpoints
+
+GET           /customs-data-store/eori/:eori/verified-email                                  uk.gov.hmrc.customs.declarations.stub.controllers.CustomsDataStoreStubController.emailIfVerified(eori)
+
+#Admin endpoints
 
 GET           /customs-declarations-stub/admin/client                                        uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationStubController.listClients()
 
@@ -26,5 +40,3 @@ GET           /customs-declarations-stub/admin/notification/:clientId/:operation
 POST          /customs-declarations-stub/admin/notification/:clientId/:operation/:lrn        uk.gov.hmrc.customs.declarations.stub.controllers.NotificationController.addNotification(clientId, operation, lrn)
 
 DELETE        /customs-declarations-stub/admin/notification/:id                              uk.gov.hmrc.customs.declarations.stub.controllers.NotificationController.deleteNotification(id)
-
-GET           /customs-data-store/eori/:eori/verified-email                                  uk.gov.hmrc.customs.declarations.stub.controllers.CustomsDataStoreStubController.emailIfVerified(eori)


### PR DESCRIPTION
As part of SPIKE it was decided that we should have
a stub implementation that we can point SFUS to in
development environment (as connecting to the real
upscan service or using the test enpoints on the
SFUS frontend service is not really possible)