### PR TITLE
[CEDS-3535] customs-declarations-stub error

### DIFF
--- a/app/uk/gov/hmrc/customs/declarations/stub/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/controllers/actions/AuthAction.scala
@@ -36,7 +36,7 @@ class AuthActionImpl @Inject()(override val authConnector: AuthConnector, cc: Co
   private val eoriNumberIdentifierKey = "EORINumber"
 
   override def invokeBlock[A](request: Request[A], block: AuthenticatedRequest[A] => Future[Result]): Future[Result] = {
-    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
     authorised(Enrolment(hmrcCusOrgEnrolmentKey))
       .retrieve(allEnrolments) { allEnrolments: Enrolments =>


### PR DESCRIPTION
Modified the AuthAction to use the `fromRequest` auth method
as opposed to the `fromRequestAndSession` method.

There appears to be a difference between the two methods in what
header values the auth lib looks at "Authorization" vs "authToken".