### PR TITLE
CEDS-3091 redirect the fake s3 bucket url to the sfus FE

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 This application provides a stubs for the following services:
 * Customs Declarations API service - that enables frontend services that use Customs Declarations API with a stub to develop locally without depending on the API. 
 * Customs Data Store service - just for the email verification endpoint (no other endpoints are stubbed here)
-* Upscan service - the 'batch-file-upload' and 's3-bucket' endpoints
 * Tariff API
 
 ## Customs Declarations API service
@@ -25,6 +24,13 @@ If LRN starts with:
 - other letters will invoke default behaviour which is Accepted notification
 
 In addition if the 2nd character of the LRN is a digit (0-9) you can control the delay in seconds of the notification delivery.
+
+### File Upload
+This stub also mocks the '/file-upload' endpoint of the Cust Dec API. This endpoint returns fake S3 urls that actually point 
+to the testOnly endpoint '/cds-file-upload-service/test-only/s3-bucket' of the CDS File Upload Frontend service.
+
+The fake S3 bucket urls have to point to a url that is available in the MTDP public zone (to allow the user's browser to upload
+files to it). This is why fake S3 urls can not point to a endpoint on this service (as it is deployed in the protected zone). 
 
 ## Customs Declarations Information stubbing
 ```
@@ -98,13 +104,6 @@ Otherwise, if the last digit of the given id is:
 - '9' - the response is Not Found (404)
 
 For any other trailing digit, the body of the OK (200) response is the content of 'conf/messages/supplementary-units-not-required.json' 
-
-## Upscan service
-Endpoint to simulate an S3 url that accepts a multipart file upload and sends the required success/failure notification to the SFUS backend service. 
-
-```
-    POST    /upscan/s3-bucket
-```
 
 ## License
 

--- a/app/uk/gov/hmrc/customs/declarations/stub/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/config/AppConfig.scala
@@ -33,9 +33,5 @@ class AppConfig @Inject()(runModeConfiguration: Configuration, servicesConfig: S
     token = loadConfig("microservice.services.client.token")
   )
 
-  val cdsFileUploadBaseUrl = servicesConfig.baseUrl("cds-file-upload")
-
   val cdsFileUploadFrontendBaseUrl = servicesConfig.baseUrl("cds-file-upload-frontend")
-
-  val upscanBaseUrl = servicesConfig.baseUrl("upscan")
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -77,22 +77,10 @@ microservice {
       token = "abc59609za2q"
     }
 
-    cds-file-upload {
-      protocol = http
-      host = localhost
-      port = 6795
-    }
-
     cds-file-upload-frontend {
       protocol = http
       host = localhost #must be a public domain in MDTP environments e.g. 'www.staging.tax.service.gov.uk'
       port = 6793
-    }
-
-    upscan {
-      protocol = http
-      host = localhost
-      port = 6790
     }
   }
 }

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -17,10 +17,6 @@ POST          /customs-declare-imports/cancellation-requests                    
 
 POST          /file-upload                                                                   uk.gov.hmrc.customs.declarations.stub.controllers.UpscanStubController.handleBatchFileUploadRequest
 
-# Upscan endpoint
-
-POST          /upscan/s3-bucket                                                              uk.gov.hmrc.customs.declarations.stub.controllers.UpscanStubController.handleS3FileUploadRequest
-
 # Customs Data Store endpoints
 
 GET           /customs-data-store/eori/:eori/verified-email                                  uk.gov.hmrc.customs.declarations.stub.controllers.CustomsDataStoreStubController.emailIfVerified(eori)

--- a/test/uk/gov/hmrc/customs/declarations/stub/base/AuthConnectorMock.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/base/AuthConnectorMock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/customs/declarations/stub/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/config/AppConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/customs/declarations/stub/connector/NotificationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/connector/NotificationConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/customs/declarations/stub/connector/NotificationValueGeneratorSpec.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/connector/NotificationValueGeneratorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/customs/declarations/stub/controllers/CustomsDataStoreStubControllerSpec.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/controllers/CustomsDataStoreStubControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/customs/declarations/stub/controllers/DeclarationsInformationStubControllerSpec.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/controllers/DeclarationsInformationStubControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/customs/declarations/stub/controllers/DeclarationsStubControllerSpec.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/controllers/DeclarationsStubControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/customs/declarations/stub/controllers/TariffApiControllerSpec.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/controllers/TariffApiControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/customs/declarations/stub/services/DeclarationStatusResponseBuilderSpec.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/services/DeclarationStatusResponseBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/customs/declarations/stub/testdata/CommonTestData.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/testdata/CommonTestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/customs/declarations/stub/testdata/xmls/SubmissionRequests.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/testdata/xmls/SubmissionRequests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Also remove the confusing fake upscan endpoint that could only be used by our FE service (not by user's browsers)