### PR TITLE
[CEDS-3091] Custom dns for first contact file upload

### DIFF
--- a/app/uk/gov/hmrc/customs/declarations/stub/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/config/AppConfig.scala
@@ -33,5 +33,6 @@ class AppConfig @Inject()(runModeConfiguration: Configuration, servicesConfig: S
     token = loadConfig("microservice.services.client.token")
   )
 
-  val cdsFileUploadFrontendBaseUrl = servicesConfig.baseUrl("cds-file-upload-frontend")
+  val cdsFileUploadFrontendPublicBaseUrl = servicesConfig.baseUrl("cds-file-upload-frontend-public")
+  val cdsFileUploadFrontendInternalBaseUrl = servicesConfig.baseUrl("cds-file-upload-frontend-internal")
 }

--- a/app/uk/gov/hmrc/customs/declarations/stub/models/upscan/FileUploadResponse.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/models/upscan/FileUploadResponse.scala
@@ -39,26 +39,6 @@ object FileUploadResponse extends Logging {
   implicit val format = Json.format[FileUploadResponse]
 
   def apply(files: List[FileUpload]): FileUploadResponse = new FileUploadResponse(files.sortBy(_.reference)) {}
-
-  def fromXml(xml: Elem): FileUploadResponse = {
-    logger.info("File Upload Response " + xml)
-    val files: List[FileUpload] = (xml \ "Files" \ "_").theSeq.collect {
-      case file =>
-        val reference = (file \ "Reference").text.trim
-        val href = (file \ "UploadRequest" \ "Href").text.trim
-        val successUrl = (file \ "UploadRequest" \ "Fields" \ "success_action_redirect").text.trim
-        val fields: Map[String, String] =
-          (file \ "UploadRequest" \ "Fields" \ "_").theSeq.collect {
-            case field if field.label == "success-action-redirect" => "success_action_redirect" -> field.text.trim
-            case field if field.label == "error-action-redirect"   => "error_action_redirect" -> field.text.trim
-            case field                                             => field.label -> field.text.trim
-          }.toMap
-
-        FileUpload(reference, Waiting(UploadRequest(href, fields)), id = successUrl.split('/').last)
-    }.toList
-
-    FileUploadResponse(files)
-  }
 }
 
 abstract class Field(value: String) {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -77,9 +77,17 @@ microservice {
       token = "abc59609za2q"
     }
 
-    cds-file-upload-frontend {
+    #must be a public domain in MDTP environments that a user's browser can reach (e.g. 'www.staging.tax.service.gov.uk')
+    cds-file-upload-frontend-public {
       protocol = http
-      host = localhost #must be a public domain in MDTP environments e.g. 'www.staging.tax.service.gov.uk'
+      host = localhost
+      port = 6793
+    }
+
+    #must be an internal domain in MDTP environments that the FE microservice can reach (e.g. 'cds-file-upload.public.mdtp')
+    cds-file-upload-frontend-internal {
+      protocol = http
+      host = localhost
       port = 6793
     }
   }


### PR DESCRIPTION
The first file in a batch upload is always the contacts file created and uploaded by the SFUS frontend itself.

In non-E2E environments (like development, staging and ET) the SFUS frontend exposed a test-only endpoint to mock the S3 bucket url that files are normally upload to. So in effect for this first file the SFUS frontend is calling itself!

The domain names that a user can access from their browser and the the service can access from its MDTP environment are not the same. So to facilitate the testing of the SFUS frontend in non-E2E environments the stub now has some special behaviour of switching the domain name for uploading the first contacts file to an internal domain that the SFUS frontend can reach.