### PR TITLE
[CEDS-3784] Improving the performance of the stub

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -109,7 +109,7 @@ metrics {
 
 auditing {
   enabled=false
-  traceRequests=true
+  traceRequests=false
   consumer {
     baseUri {
       host = localhost

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -7,13 +7,7 @@ POST          /                                                                 
 
 POST          /cancellation-requests                                                         uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationStubController.cancel()
 
-GET           /last-submission                                                               uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationStubController.lastSubmit()
-
 GET           /mrn/:mrn/status                                                               uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationsInformationStubController.getDeclarationStatus(mrn)
-
-POST          /customs-declare-imports/                                                      uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationStubController.submitNoNotification()
-
-POST          /customs-declare-imports/cancellation-requests                                 uk.gov.hmrc.customs.declarations.stub.controllers.DeclarationStubController.cancelNoNotification()
 
 POST          /file-upload                                                                   uk.gov.hmrc.customs.declarations.stub.controllers.UpscanStubController.handleBatchFileUploadRequest
 

--- a/test/uk/gov/hmrc/customs/declarations/stub/controllers/DeclarationsStubControllerSpec.scala
+++ b/test/uk/gov/hmrc/customs/declarations/stub/controllers/DeclarationsStubControllerSpec.scala
@@ -50,8 +50,6 @@ class DeclarationsStubControllerSpec
 
   val submissionUri = "/"
   val cancellationUri = "/cancellation-requests"
-  val submissionNoNotificationUri = "/customs-declare-imports/"
-  val cancellationNoNotificationUri = "/customs-declare-imports/cancellation-requests"
 
   def buildFakeRequest(xmlBody: String, method: String, uriVal: String): FakeRequest[String] =
     FakeRequest(method, uriVal)
@@ -68,12 +66,6 @@ class DeclarationsStubControllerSpec
 
   val fakeCancellationXmlRequest: FakeRequest[String] =
     buildFakeRequest(validCancellationXml.toString, "POST", cancellationUri)
-
-  val fakeSubmissionNoNotificationXmlRequest: FakeRequest[String] =
-    buildFakeRequest(validSubmissionXml.toString, "POST", submissionNoNotificationUri)
-
-  val fakeCancellationNoNotificationXmlRequest: FakeRequest[String] =
-    buildFakeRequest(validCancellationXml.toString, "POST", cancellationNoNotificationUri)
 
   val mockAuthConnector: AuthConnector = mock[AuthConnector]
   val mockClientRepo: ClientRepository = mock[ClientRepository]
@@ -152,59 +144,6 @@ class DeclarationsStubControllerSpec
         status(result) should be(BAD_REQUEST)
         verifyNoMoreInteractions(mockNotificationConnector)
       }
-
-    }
-
-    "No Notification Endpoints" should {
-      "return ACCEPTED, not send notification when submissionNoNotification endpoint called " in {
-        when(
-          mockAuthConnector.authorise(any[Predicate], any[Retrieval[Unit]])(any[HeaderCarrier], any[ExecutionContext])
-        ).thenReturn(Future.successful(()))
-        when(mockClientRepo.findByClientId(any())).thenReturn(Future.successful(Some(client)))
-
-        val result = route(app, fakeSubmissionNoNotificationXmlRequest).get
-
-        status(result) should be(ACCEPTED)
-        verifyNoMoreInteractions(mockNotificationConnector)
-      }
-
-      "return BADREQUEST when invalidxml is sent to submission Endpoint" in {
-        when(
-          mockAuthConnector.authorise(any[Predicate], any[Retrieval[Unit]])(any[HeaderCarrier], any[ExecutionContext])
-        ).thenReturn(Future.successful(()))
-        when(mockClientRepo.findByClientId(any())).thenReturn(Future.successful(Some(client)))
-
-        val result = route(app, fakeSubmissionNoNotificationXmlRequest.withBody("<some></some>")).get
-
-        status(result) should be(BAD_REQUEST)
-        verifyNoMoreInteractions(mockNotificationConnector)
-      }
-
-      "return ACCEPTED, not send notification when cancellationNoNotification endpoint called " in {
-        when(
-          mockAuthConnector.authorise(any[Predicate], any[Retrieval[Unit]])(any[HeaderCarrier], any[ExecutionContext])
-        ).thenReturn(Future.successful(()))
-        when(mockClientRepo.findByClientId(any())).thenReturn(Future.successful(Some(client)))
-
-        val result = route(app, fakeCancellationNoNotificationXmlRequest).get
-
-        status(result) should be(ACCEPTED)
-        verifyNoMoreInteractions(mockNotificationConnector)
-      }
-
-      "return BADREQUEST when invalidxml is sent to cancellation Endpoint" in {
-        when(
-          mockAuthConnector.authorise(any[Predicate], any[Retrieval[Unit]])(any[HeaderCarrier], any[ExecutionContext])
-        ).thenReturn(Future.successful(()))
-        when(mockClientRepo.findByClientId(any())).thenReturn(Future.successful(Some(client)))
-
-        val result = route(app, fakeCancellationNoNotificationXmlRequest.withBody("<some></some>")).get
-
-        status(result) should be(BAD_REQUEST)
-        verifyNoMoreInteractions(mockNotificationConnector)
-      }
-
     }
   }
-
 }


### PR DESCRIPTION
Cleaned out old imports related endpoints that were caching the XML payload sent in memory

Added log statement on startup to report schema validation as being on or off

Turned off auditing for requests (as we were getting some timeouts with the auditing calls)