### PR TITLE
[CEDS-3854] Make stub send timestamps adjusting for BST

### DIFF
--- a/app/uk/gov/hmrc/customs/declarations/stub/generators/NotificationGenerator.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/generators/NotificationGenerator.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.customs.declarations.stub.generators
 import uk.gov.hmrc.customs.declarations.stub.generators.NotificationGenerator.FunctionCode
 import uk.gov.hmrc.customs.declarations.stub.utils.XmlPayloads._
 
-import java.time.LocalDateTime
+import java.time.{ZoneId, ZonedDateTime}
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 import javax.inject.Inject
@@ -28,10 +28,10 @@ import scala.xml._
 
 class NotificationGenerator @Inject()(notificationValueGenerator: NotificationValueGenerator) {
 
-  val format304: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss'Z'")
+  val format304: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssX")
 
   def generate(lrn: String, statuses: Seq[FunctionCode]): Elem = {
-    val issueAt = LocalDateTime.now()
+    val issueAt = ZonedDateTime.now(ZoneId.of("Europe/London"))
     val random = new Random(lrn.hashCode)
 
     val mrn = {
@@ -83,7 +83,7 @@ class NotificationGenerator @Inject()(notificationValueGenerator: NotificationVa
   private def notificationResponse(
     code: FunctionCode,
     declaration: NodeSeq,
-    issuedAt: LocalDateTime,
+    issuedAt: ZonedDateTime,
     lrn: String
   ): Elem = {
 

--- a/app/uk/gov/hmrc/customs/declarations/stub/utils/XmlPayloads.scala
+++ b/app/uk/gov/hmrc/customs/declarations/stub/utils/XmlPayloads.scala
@@ -16,16 +16,17 @@
 
 package uk.gov.hmrc.customs.declarations.stub.utils
 
-import java.time.LocalDateTime
+import java.time.{ZoneId, ZonedDateTime}
 import java.time.format.DateTimeFormatter
 
 object XmlPayloads {
 
-  val firstDate = LocalDateTime.now()
+  val firstDate = ZonedDateTime.now(ZoneId.of("Europe/London"))
   val secondDate = firstDate.plusMinutes(5)
   val thirdDate = firstDate.plusMinutes(10)
 
-  def adjustTime(time: LocalDateTime): String = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(time) + "Z"
+  def adjustTime(time: ZonedDateTime): String =
+    time.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssX"))
 
   // scalastyle:off
   def acceptedExportNotification(mrn: String = "18GBJCM3USAFD2WD51") =


### PR DESCRIPTION
Before we were creating LocalDateTime values and passing them off as UTC values (even when they were infact BST values).